### PR TITLE
Clarify disabling annotations should not change meaning of executions

### DIFF
--- a/contracts_use_cases.html
+++ b/contracts_use_cases.html
@@ -62,8 +62,8 @@ expectations</td>
 <tr><td><a href="#dev.reason.sideeffects">dev.reason.sideeffects</a></td>
   <td>Developer</td>
   <td>Reason about executions</td>
-  <td>Ensure annotations do not substantially change the meaning of my program when
-enabled</td>
+  <td>Ensure annotations do not substantially change the meaning of my program
+whether enabled or disabled</td>
   <td></td></tr>
 
 <tr><td><a href="#dev.reason.behaviorcontrol">dev.reason.behaviorcontrol</a></td>

--- a/generator/all_data.txt
+++ b/generator/all_data.txt
@@ -94,8 +94,8 @@ leveraging expectations of behavior across all compliant platforms.
 --dev.reason.sideeffects
 Developer
 Reason about executions
-Ensure annotations do not substantially change the meaning of my program when
-enabled
+Ensure annotations do not substantially change the meaning of my program whether
+enabled or disabled
 ==categories
 general behavior
 ==description

--- a/generator/generated/all_data.txt
+++ b/generator/generated/all_data.txt
@@ -94,8 +94,8 @@ leveraging expectations of behavior across all compliant platforms.
 --dev.reason.sideeffects
 Developer
 Reason about executions
-Ensure annotations do not substantially change the meaning of my program when
-enabled
+Ensure annotations do not substantially change the meaning of my program
+whether enabled or disabled
 ==categories
 general behavior
 ==description

--- a/generator/generated/contracts_use_cases2.html
+++ b/generator/generated/contracts_use_cases2.html
@@ -62,8 +62,8 @@ expectations</td>
 <tr><td><a href="#dev.reason.sideeffects">dev.reason.sideeffects</a></td>
   <td>Developer</td>
   <td>Reason about executions</td>
-  <td>Ensure annotations do not substantially change the meaning of my program when
-enabled</td>
+  <td>Ensure annotations do not substantially change the meaning of my program
+whether enabled or disabled</td>
   </tr>
 
 <tr><td><a href="#dev.reason.behaviorcontrol">dev.reason.behaviorcontrol</a></td>
@@ -1372,8 +1372,8 @@ leveraging expectations of behavior across all compliant platforms.</p>
 <h1><a name="dev.reason.sideeffects">dev.reason.sideeffects</a></h1>
 <i>As a</i> Developer <br/>
 <i>In order to</i> Reason about executions <br/>
-<i>I want to</i> Ensure annotations do not substantially change the meaning of my program when
-enabled <p/>
+<i>I want to</i> Ensure annotations do not substantially change the meaning of my program
+whether enabled or disabled <p/>
 <p>There is a tension between allowing side effects in contract conditions and
 disallowing them completely.  In general, writing code with absolutely no side
 effects is very hard, and there are pitfalls if the language is actively

--- a/generator/generated/survey.txt
+++ b/generator/generated/survey.txt
@@ -31,8 +31,8 @@ Not important
 Nice to have
 Must have
 
-As a Developer, in order to Reason about executions, I want to Ensure annotations do not substantially change the meaning of my program when
-enabled 
+As a Developer, in order to Reason about executions, I want to Ensure annotations do not substantially change the meaning of my program
+whether enabled or disabled 
 Not important
 Nice to have
 Must have


### PR DESCRIPTION
This is a minor fix. No need to update the current survey.